### PR TITLE
Document running `git multi` as a git subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ There are plenty of other utilities out there that do something similar, but typ
 
 ## Usage
 
+Installing the gem installs the `git-multi` executable on your system's `${PATH}`, which means it can be run as a so-called [git subcommand](https://git.github.io/htmldocs/howto/new-command.html#:~:text=Runtime%20environment), as follows: `git multi`; a good starting point is:
+
     $ git multi --help
 
 ## Known Issues


### PR DESCRIPTION
This closes #1 by properly documenting how to run `git-multi` as a so-called git subcommand.