### PR TITLE
Document chaining multiple `git multi` invocations

### DIFF
--- a/man/git-multi.1
+++ b/man/git-multi.1
@@ -2,12 +2,12 @@
 .\"     Title: git-multi
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 04/12/2021
+.\"      Date: 04/13/2021
 .\"    Manual: Git Manual
 .\"    Source: Git 2.31.1.272.g89b43f80a5.dirty
 .\"  Language: English
 .\"
-.TH "GIT\-MULTI" "1" "04/12/2021" "Git 2\&.31\&.1\&.272\&.g89b43f" "Git Manual"
+.TH "GIT\-MULTI" "1" "04/13/2021" "Git 2\&.31\&.1\&.272\&.g89b43f" "Git Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -482,8 +482,6 @@ git multi \-\-graph | ruby \-n \-e \*(Aqparent, children = $_\&.split(": ") ; pu
 .if n \{\
 .RE
 .\}
-.sp
-query only repos that are not archived git multi ++multi_repo \-\-json | jq \-r \fI\&.[] | select(\&."archived" == false) | \&."full_name"\fR | git multi \&...
 .SH "QUERY ARGUMENTS"
 .sp
 The following is a list of valid arguments for the \fBgit multi \-\-query\fR option:
@@ -543,6 +541,33 @@ git multi \-\-json | jq \-r \*(Aq\&.[] | \&.name + ": " + \&.description\*(Aq
 .nf
 # print out the name of all "forked" repositories
 git multi \-\-json | jq \-r \*(Aq\&.[] | select(\&.fork == true) | \&.full_name\*(Aq
+.fi
+.if n \{\
+.RE
+.\}
+.SH "CHAINED INVOCATION"
+.sp
+When \fBgit multi\fR gets its input from a Unix pipeline \fI(as opposed to from a TTY)\fR, it constructs an "implicit" multi repo comprised of the "full" repo names it reads from \fBSTDIN\fR \fI(one full repo name per line)\fR\&.
+.sp
+This allows multiple \fBgit multi\fR invocations to be chained, for example by using the \fB\-\-json\fR or \fB\-\-find\fR options as follows:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+# run a git query or subcommand on repos that aren\*(Aqt archived (on GitHub)
+git multi ++<multi_repo> \-\-json | jq \-r \*(Aq\&.[] | select(\&."archived" == false) | \&."full_name"\*(Aq | git multi <git_command>
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+# run a shell command inside repos that have Ruby as their main language
+git multi ++<multi_repo> \-\-find \*(Aqlanguage == "Ruby"\*(Aq | git multi \-\-raw \*(Aqcat \&.ruby\-version\*(Aq
 .fi
 .if n \{\
 .RE

--- a/man/git-multi.erb
+++ b/man/git-multi.erb
@@ -225,9 +225,6 @@ generate a dependency graph of all organization repositories using Graphviz
 
  git multi --graph | ruby -n -e 'parent, children = $_.split(": ") ; puts children.split(" ").map { |child| "\"#{parent}\"->\"#{child}\";" }' | awk 'BEGIN { print "digraph {\nrankdir=\"LR\";\n" } ; { print ; } END { print "}\n" } ; ' | dot -Tpng > /tmp/ghor.png ; open -a Preview /tmp/ghor.png
 
-query only repos that are not archived
- git multi ++multi_repo --json | jq -r '.[] | select(."archived" == false) | ."full_name"' | git multi ...
-
 QUERY ARGUMENTS
 ---------------
 
@@ -248,6 +245,19 @@ are some examples:
 
  # print out the name of all "forked" repositories
  git multi --json | jq -r '.[] | select(.fork == true) | .full_name'
+
+CHAINED INVOCATION
+------------------
+
+When `git multi` gets its input from a Unix pipeline _(as opposed to from a TTY)_, it constructs an "implicit" multi repo comprised of the "full" repo names it reads from `STDIN` _(one full repo name per line)_.
+
+This allows multiple `git multi` invocations to be chained, for example by using the `--json` or `--find` options as follows:
+
+ # run a git query or subcommand on repos that aren't archived (on GitHub)
+ git multi ++<multi_repo> --json | jq -r '.[] | select(."archived" == false) | ."full_name"' | git multi <git_command>
+
+ # run a shell command inside repos that have Ruby as their main language
+ git multi ++<multi_repo> --find 'language == "Ruby"' | git multi --raw 'cat .ruby-version'
 
 FILES
 -----

--- a/man/git-multi.html
+++ b/man/git-multi.html
@@ -1105,8 +1105,6 @@ and cached locally <em>(in binary format)</em> for performance and offline usage
 <div class="content">
 <pre><code>git multi --graph | ruby -n -e 'parent, children = $_.split(": ") ; puts children.split(" ").map { |child| "\"#{parent}\"-&gt;\"#{child}\";" }' | awk 'BEGIN { print "digraph {\nrankdir=\"LR\";\n" } ; { print ; } END { print "}\n" } ; ' | dot -Tpng &gt; /tmp/ghor.png ; open -a Preview /tmp/ghor.png</code></pre>
 </div></div>
-<div class="paragraph"><p>query only repos that are not archived
- git multi ++multi_repo --json | jq -r <em>.[] | select(."archived" == false) | ."full_name"</em> | git multi &#8230;</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -1160,6 +1158,23 @@ git multi --json | jq -r '.[] | .name + ": " + .description'</code></pre>
 <div class="content">
 <pre><code># print out the name of all "forked" repositories
 git multi --json | jq -r '.[] | select(.fork == true) | .full_name'</code></pre>
+</div></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_chained_invocation">CHAINED INVOCATION</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>When <code>git multi</code> gets its input from a Unix pipeline <em>(as opposed to from a TTY)</em>, it constructs an "implicit" multi repo comprised of the "full" repo names it reads from <code>STDIN</code> <em>(one full repo name per line)</em>.</p></div>
+<div class="paragraph"><p>This allows multiple <code>git multi</code> invocations to be chained, for example by using the <code>--json</code> or <code>--find</code> options as follows:</p></div>
+<div class="literalblock">
+<div class="content">
+<pre><code># run a git query or subcommand on repos that aren't archived (on GitHub)
+git multi ++&lt;multi_repo&gt; --json | jq -r '.[] | select(."archived" == false) | ."full_name"' | git multi &lt;git_command&gt;</code></pre>
+</div></div>
+<div class="literalblock">
+<div class="content">
+<pre><code># run a shell command inside repos that have Ruby as their main language
+git multi ++&lt;multi_repo&gt; --find 'language == "Ruby"' | git multi --raw 'cat .ruby-version'</code></pre>
 </div></div>
 </div>
 </div>
@@ -1224,7 +1239,7 @@ the <code>jq</code> command-line utility:
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2021-04-12 17:23:42 BST
+ 2021-04-13 08:36:59 BST
 </div>
 </div>
 </body>


### PR DESCRIPTION
A relatively recent change in `git-multi` added support for "implicit" multi-repos comprised of "full" repo names read from `STDIN` ... this allows `git-multi` used inside UNIX pipelines to operate on a set of repositories that match certain criteria, as per the examples provided in this PR.